### PR TITLE
make it secure by default with -k to disable cert validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ We use [semantic versioning](http://semver.org/):
 
 # Next Release
 
+- [breaking change] certificates are now validated by default. Use `--insecure` to disable validation
 - [feature] allow users to provide self-signed certificates that should be trusted in a Java keystore
 - [feature] allow users to append lines to the default message
 

--- a/src/main/java/com/cqse/teamscaleupload/TeamscaleUpload.java
+++ b/src/main/java/com/cqse/teamscaleupload/TeamscaleUpload.java
@@ -70,7 +70,7 @@ public class TeamscaleUpload {
             this.url = HttpUrl.parse(namespace.getString("server"));
             this.message = namespace.getString("message");
             this.keystorePathAndPassword = namespace.getString("trusted_keystore");
-            this.validateSsl = namespace.getBoolean("validate_ssl") || keystorePathAndPassword != null;
+            this.validateSsl = !namespace.getBoolean("insecure") || keystorePathAndPassword != null;
             this.additionalMessageLines = getListSafe(namespace, "append_to_message");
 
             String inputFilePath = namespace.getString("input");
@@ -223,10 +223,9 @@ public class TeamscaleUpload {
                         " environment variables or a Git or SVN checkout in the current working" +
                         " directory. If guessing fails, the upload will fail. This feature supports" +
                         " many common CI tools like Jenkins, GitLab, GitHub Actions, Travis CI etc.");
-        parser.addArgument("--validate-ssl").action(Arguments.storeTrue()).required(false)
-                .help("By default, SSL certificates are accepted without validation, which makes" +
-                        " using this tool with self-signed certificates easier. This flag enables" +
-                        " validation.");
+        parser.addArgument("-k", "--insecure").action(Arguments.storeTrue()).required(false)
+                .help("Causes SSL certificates to be accepted without validation, which makes" +
+                        " using this tool with self-signed or invalid certificates easier.");
         parser.addArgument("--trusted-keystore").required(false)
                 .help("A Java keystore file and its corresponding password. The keystore contains" +
                         " additional certificates that should be trusted when performing SSL requests." +

--- a/src/main/java/com/cqse/teamscaleupload/TeamscaleUpload.java
+++ b/src/main/java/com/cqse/teamscaleupload/TeamscaleUpload.java
@@ -125,16 +125,7 @@ public class TeamscaleUpload {
                 throw new ArgumentParserException("You provided an invalid URL in the --server option", parser);
             }
 
-            if (!validateSsl && keystorePathAndPassword != null) {
-                warn("You specified a trusted keystore via --trust-keystore but also disabled SSL" +
-                        " validation via --insecure. SSL validation is now disabled and your keystore" +
-                        " will not be used.");
-            }
-
-            if (keystorePathAndPassword != null && !keystorePathAndPassword.contains(";")) {
-                throw new ArgumentParserException("You forgot to add the password for the --trust-keystore file " + keystorePathAndPassword + "." +
-                        " You must add it to the end of the path, separated by a semicolon, e.g: --trust-keystore " + keystorePathAndPassword + ";PASSWORD", parser);
-            }
+            validateKeystoreSettings(parser);
 
             if (hasMoreThanOneCommitOptionSet()) {
                 throw new ArgumentParserException("You used more than one of --detect-commit, --commit and --timestamp." +
@@ -151,6 +142,19 @@ public class TeamscaleUpload {
             if (!files.isEmpty() && format == null) {
                 throw new ArgumentParserException("Please specify a report format with --format " +
                         "if you pass report patterns as command line arguments", parser);
+            }
+        }
+
+        private void validateKeystoreSettings(ArgumentParser parser) throws ArgumentParserException {
+            if (!validateSsl && keystorePathAndPassword != null) {
+                warn("You specified a trusted keystore via --trust-keystore but also disabled SSL" +
+                        " validation via --insecure. SSL validation is now disabled and your keystore" +
+                        " will not be used.");
+            }
+
+            if (keystorePathAndPassword != null && !keystorePathAndPassword.contains(";")) {
+                throw new ArgumentParserException("You forgot to add the password for the --trust-keystore file " + keystorePathAndPassword + "." +
+                        " You must add it to the end of the path, separated by a semicolon, e.g: --trust-keystore " + keystorePathAndPassword + ";PASSWORD", parser);
             }
         }
 
@@ -551,7 +555,7 @@ public class TeamscaleUpload {
         System.exit(1);
     }
 
-    public static void warn(String message) {
+    private static void warn(String message) {
         System.err.println("WARNING: " + message);
     }
 

--- a/src/main/java/com/cqse/teamscaleupload/TeamscaleUpload.java
+++ b/src/main/java/com/cqse/teamscaleupload/TeamscaleUpload.java
@@ -70,7 +70,7 @@ public class TeamscaleUpload {
             this.url = HttpUrl.parse(namespace.getString("server"));
             this.message = namespace.getString("message");
             this.keystorePathAndPassword = namespace.getString("trusted_keystore");
-            this.validateSsl = !namespace.getBoolean("insecure") || keystorePathAndPassword != null;
+            this.validateSsl = !namespace.getBoolean("insecure");
             this.additionalMessageLines = getListSafe(namespace, "append_to_message");
 
             String inputFilePath = namespace.getString("input");
@@ -123,6 +123,12 @@ public class TeamscaleUpload {
         public void validate(ArgumentParser parser) throws ArgumentParserException {
             if (url == null) {
                 throw new ArgumentParserException("You provided an invalid URL in the --server option", parser);
+            }
+
+            if (!validateSsl && keystorePathAndPassword != null) {
+                warn("You specified a trusted keystore via --trust-keystore but also disabled SSL" +
+                        " validation via --insecure. SSL validation is now disabled and your keystore" +
+                        " will not be used.");
             }
 
             if (keystorePathAndPassword != null && !keystorePathAndPassword.contains(";")) {
@@ -543,6 +549,10 @@ public class TeamscaleUpload {
     public static void fail(String message) {
         System.err.println(message);
         System.exit(1);
+    }
+
+    public static void warn(String message) {
+        System.err.println("WARNING: " + message);
     }
 
     private static String readBodySafe(Response response) {

--- a/src/main/java/com/cqse/teamscaleupload/TeamscaleUpload.java
+++ b/src/main/java/com/cqse/teamscaleupload/TeamscaleUpload.java
@@ -303,7 +303,9 @@ public class TeamscaleUpload {
                     " or some certificates are missing from it." +
                     "\nPlease also ensure that your Teamscale instance is reachable under " + input.url +
                     " and that it is configured for HTTPS, not HTTP. E.g. open that URL in your" +
-                    " browser and verify that you can connect successfully.");
+                    " browser and verify that you can connect successfully." +
+                    "\n\nIf you want to accept self-signed or broken certificates without an error" +
+                    " you can use --insecure.");
         } else if (input.validateSsl) {
             fail("Failed to connect via HTTPS to " + input.url + ": " + e.getMessage() +
                     "\nYou enabled certificate validation. Most likely, your certificate" +
@@ -315,12 +317,16 @@ public class TeamscaleUpload {
                     " https://docs.teamscale.com/howto/connecting-via-https/#using-self-signed-certificates" +
                     "\nPlease also ensure that your Teamscale instance is reachable under " + input.url +
                     " and that it is configured for HTTPS, not HTTP. E.g. open that URL in your" +
-                    " browser and verify that you can connect successfully.");
+                    " browser and verify that you can connect successfully." +
+                    "\n\nIf you want to accept self-signed or broken certificates without an error" +
+                    " you can use --insecure.");
         } else {
             fail("Failed to connect via HTTPS to " + input.url + ": " + e.getMessage() +
                     "\nPlease ensure that your Teamscale instance is reachable under " + input.url +
                     " and that it is configured for HTTPS, not HTTP. E.g. open that URL in your" +
-                    " browser and verify that you can connect successfully.");
+                    " browser and verify that you can connect successfully." +
+                    "\n\nIf you want to accept self-signed or broken certificates without an error" +
+                    " you can use --insecure.");
         }
     }
 

--- a/src/test/java/com/cqse/teamscaleupload/NativeImageIT.java
+++ b/src/test/java/com/cqse/teamscaleupload/NativeImageIT.java
@@ -128,9 +128,10 @@ public class NativeImageIT {
     }
 
     @Test
-    public void selfSignedCertificateShouldBeAcceptedByDefault() {
+    public void selfSignedCertificateShouldBeAcceptedIfInsecureIsChosen() {
         try (TeamscaleMockServer server = new TeamscaleMockServer(MOCK_TEAMSCALE_PORT, true)) {
-            ProcessUtils.ProcessResult result = runUploader(new Arguments().withUrl("https://localhost:" + MOCK_TEAMSCALE_PORT));
+            ProcessUtils.ProcessResult result = runUploader(new Arguments().withUrl("https://localhost:" + MOCK_TEAMSCALE_PORT)
+                    .withInsecure());
             assertThat(result.exitCode)
                     .describedAs("Stderr and stdout: " + result.stdoutAndStdErr)
                     .isZero();
@@ -142,8 +143,7 @@ public class NativeImageIT {
     public void selfSignedCertificateShouldNotBeAcceptedWhenValidationIsEnabled() {
         try (TeamscaleMockServer ignored = new TeamscaleMockServer(MOCK_TEAMSCALE_PORT, true)) {
             ProcessUtils.ProcessResult result = runUploader(new Arguments()
-                    .withUrl("https://localhost:" + MOCK_TEAMSCALE_PORT)
-                    .withSslValidation());
+                    .withUrl("https://localhost:" + MOCK_TEAMSCALE_PORT));
             assertThat(result.exitCode)
                     .describedAs("Stderr and stdout: " + result.stdoutAndStdErr)
                     .isNotZero();
@@ -155,8 +155,7 @@ public class NativeImageIT {
     public void selfSignedCertificateShouldBeAcceptedWhenKeystoreIsUsed() {
         try (TeamscaleMockServer server = new TeamscaleMockServer(MOCK_TEAMSCALE_PORT, true)) {
             ProcessUtils.ProcessResult result = runUploader(new Arguments()
-                    .withUrl("https://localhost:" + MOCK_TEAMSCALE_PORT)
-                    .withSslValidation().withKeystore());
+                    .withUrl("https://localhost:" + MOCK_TEAMSCALE_PORT).withKeystore());
             assertThat(result.exitCode)
                     .describedAs("Stderr and stdout: " + result.stdoutAndStdErr)
                     .isZero();
@@ -186,7 +185,7 @@ public class NativeImageIT {
         private final String partition = "NativeImageIT";
         private String pattern = "coverage_files\\*.simple";
         private String input = null;
-        private boolean validateSsl = false;
+        private boolean insecure = false;
         private boolean useKeystore = false;
         private String additionalMessageLine = null;
 
@@ -195,8 +194,8 @@ public class NativeImageIT {
             return this;
         }
 
-        private Arguments withSslValidation() {
-            this.validateSsl = true;
+        private Arguments withInsecure() {
+            this.insecure = true;
             return this;
         }
 
@@ -243,8 +242,8 @@ public class NativeImageIT {
                 arguments.add(input);
             }
             arguments.add(pattern);
-            if (validateSsl) {
-                arguments.add("--validate-ssl");
+            if (insecure) {
+                arguments.add("--insecure");
             }
             if (useKeystore) {
                 arguments.add("--trusted-keystore");

--- a/src/test/java/com/cqse/teamscaleupload/NativeImageIT.java
+++ b/src/test/java/com/cqse/teamscaleupload/NativeImageIT.java
@@ -147,7 +147,7 @@ public class NativeImageIT {
             assertThat(result.exitCode)
                     .describedAs("Stderr and stdout: " + result.stdoutAndStdErr)
                     .isNotZero();
-            assertThat(result.stdoutAndStdErr).contains("self-signed");
+            assertThat(result.stdoutAndStdErr).contains("self-signed").contains("--insecure");
         }
     }
 


### PR DESCRIPTION
- [x] Changes are tested adequately
- [ ] Teamscale documentation updated in case of relevant user-visible changes - TBD after release
- [x] CHANGELOG.md updated
- [x] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or false positives. If you feel that the Teamscale config or architecture file needs adjustment, please state so in a comment and discuss this with your reviewer.

