### PR TITLE
fix incorrect encoding of URLs in error messages

### DIFF
--- a/src/main/java/com/teamscale/upload/CommandLine.java
+++ b/src/main/java/com/teamscale/upload/CommandLine.java
@@ -40,7 +40,7 @@ public class CommandLine {
 	public static final String TEAMSCALE_ACCESS_KEY_ENVIRONMENT_VARIABLE = "TEAMSCALE_ACCESS_KEY";
 
 	/**
-	 * The Teamscale project ID or alias.
+	 * The Teamscale project ID.
 	 */
 	public final String project;
 	/**
@@ -199,7 +199,7 @@ public class CommandLine {
 		parser.addArgument("-s", "--server").metavar("URL").required(true)
 				.help("The url under which the Teamscale server can be reached.");
 		parser.addArgument("-p", "--project").metavar("PROJECT").required(true)
-				.help("The project ID or alias (NOT the project name!) to which to upload the data.");
+				.help("The project ID (NOT the project name!) to which to upload the data.");
 		parser.addArgument("-u", "--user").metavar("USER").required(true)
 				.help("The username used to perform the upload. Must have the"
 						+ " 'Perform External Uploads' permission for the given Teamscale project.");

--- a/src/main/java/com/teamscale/upload/TeamscaleUpload.java
+++ b/src/main/java/com/teamscale/upload/TeamscaleUpload.java
@@ -21,6 +21,7 @@ import com.teamscale.upload.utils.LogUtils;
 import com.teamscale.upload.utils.MessageUtils;
 import com.teamscale.upload.utils.OkHttpUtils;
 import com.teamscale.upload.utils.SafeResponse;
+import com.teamscale.upload.utils.TeamscaleUrlUtils;
 import com.teamscale.upload.xcode.XCResultConverter;
 import com.teamscale.upload.xcode.XCResultConverter.ConversionException;
 
@@ -335,24 +336,20 @@ public class TeamscaleUpload {
 		}
 
 		if (response.unsafeResponse.code() == 401) {
-			HttpUrl editUserUrl = commandLine.url.newBuilder().addPathSegments("admin.html#users")
-					.addQueryParameter("action", "edit").addQueryParameter("username", commandLine.username).build();
+			String editUserUrl = TeamscaleUrlUtils.getEditUserUrl(commandLine.url, commandLine.username);
 			LogUtils.fail("You provided incorrect credentials." + " Either the user '" + commandLine.username
 					+ "' does not exist in Teamscale" + " or the access key you provided is incorrect."
-					+ " Please check both the username and access key in Teamscale under Admin > Users:" + " "
+					+ " Please check both the username and access key in Teamscale under Admin > Users: "
 					+ editUserUrl + "\nPlease use the user's access key, not their password.", response);
 		}
 
 		if (response.unsafeResponse.code() == 403) {
-			// can't include a URL to the corresponding Teamscale screen since that page
-			// does not support aliases
-			// and the user may have provided an alias, so we'd be directing them to a red
-			// error page in that case
+			String projectPermissionUrl = TeamscaleUrlUtils.getProjectPermissionUrl(commandLine.url, commandLine.project);
 			LogUtils.fail("The user user '" + commandLine.username
 					+ "' is not allowed to upload data to the Teamscale project '" + commandLine.project + "'."
 					+ " Please grant this user the 'Perform External Uploads' permission in Teamscale"
-					+ " under Project Configuration > Projects by clicking on the button showing three"
-					+ " persons next to project '" + commandLine.project + "'.", response);
+					+ " under Project Configuration > Projects: " + projectPermissionUrl
+					+ "\nE.g. by assigning them the 'Build' role for that project.", response);
 		}
 
 		if (response.unsafeResponse.code() == 404) {
@@ -375,10 +372,10 @@ public class TeamscaleUpload {
 					+ " (e.g. your Git commit has been pushed).", response);
 		}
 
-		HttpUrl projectPerspectiveUrl = commandLine.url.newBuilder().addPathSegments("project.html").build();
-		LogUtils.fail("The project with ID or alias '" + commandLine.project + "' does not seem to exist in Teamscale."
-				+ " Please ensure that you used the project ID or the project alias, NOT the project name."
-				+ " You can see the IDs of all projects at " + projectPerspectiveUrl
+		LogUtils.fail("The project with ID '" + commandLine.project + "' does not seem to exist in Teamscale."
+				+ " Please ensure that you used one of the project IDs, NOT the project name."
+				+ " You can see the IDs of all projects at "
+				+ TeamscaleUrlUtils.getProjectPerspectiveUrl(commandLine.url)
 				+ "\nPlease also ensure that the Teamscale URL is correct and no proxy is required to access it.",
 				response);
 	}

--- a/src/main/java/com/teamscale/upload/utils/TeamscaleUrlUtils.java
+++ b/src/main/java/com/teamscale/upload/utils/TeamscaleUrlUtils.java
@@ -1,0 +1,39 @@
+package com.teamscale.upload.utils;
+
+import okhttp3.HttpUrl;
+
+/**
+ * Utils to construct Teamscale URLs to be displayed to the user, e.g. in error
+ * messages. This handles some Teamscale quirks. E.g. Teamscale always expects
+ * the fragment ("#user" etc.) to appear before the query parameters.
+ */
+public class TeamscaleUrlUtils {
+
+	/** Returns a URL to the edit page of the given user. */
+	public static String getEditUserUrl(HttpUrl teamscaleBaseUrl, String username) {
+		return fixFragment(teamscaleBaseUrl.newBuilder().addPathSegment("admin.html#users")
+				.addQueryParameter("action", "edit").addQueryParameter("username", username));
+	}
+
+	/** Returns a URL to the edit page of the given user. */
+	public static String getProjectPermissionUrl(HttpUrl teamscaleBaseUrl, String project) {
+		return fixFragment(teamscaleBaseUrl.newBuilder().addPathSegment("project.html#project")
+				.addQueryParameter("name", project).addQueryParameter("action", "roles"));
+	}
+
+	/**
+	 * Teamscale requires that the fragment be present before the query parameters.
+	 * OkHttp always encodes the fragment after the query parameters. So we have to
+	 * encode the fragment in the path, which unfortunately escapes the "#"
+	 * separator. This function undoes this unwanted encoding.
+	 */
+	private static String fixFragment(HttpUrl.Builder url) {
+		return url.toString().replaceFirst("%23", "#");
+	}
+
+	/** Returns a URL to the project perspective. */
+	public static String getProjectPerspectiveUrl(HttpUrl teamscaleBaseUrl) {
+		return teamscaleBaseUrl.newBuilder().addPathSegments("project.html").toString();
+	}
+
+}

--- a/src/test/java/com/teamscale/upload/NativeImageIT.java
+++ b/src/test/java/com/teamscale/upload/NativeImageIT.java
@@ -134,7 +134,7 @@ public class NativeImageIT {
 			softly.assertThat(result.exitCode).isNotZero();
 			softly.assertThat(result.errorOutput).doesNotContain("The project")
 					.doesNotContain("does not seem to exist in Teamscale")
-					.doesNotContain("project ID or the project alias").contains("The revision")
+					.doesNotContain("project ID").contains("The revision")
 					.contains("is not known to Teamscale or the version control system(s) you configured");
 		});
 	}

--- a/src/test/java/com/teamscale/upload/utils/TeamscaleUrlUtilsTest.java
+++ b/src/test/java/com/teamscale/upload/utils/TeamscaleUrlUtilsTest.java
@@ -1,0 +1,29 @@
+package com.teamscale.upload.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import okhttp3.HttpUrl;
+
+class TeamscaleUrlUtilsTest {
+
+	@Test
+	void testEditUserUrl() {
+		String url = TeamscaleUrlUtils.getEditUserUrl(HttpUrl.get("http://localhost:8080"), "build");
+		assertEquals("http://localhost:8080/admin.html#users?action=edit&username=build", url);
+	}
+
+	@Test
+	void testProjectPermissionUrl() {
+		String url = TeamscaleUrlUtils.getProjectPermissionUrl(HttpUrl.get("http://localhost:8080"), "proj");
+		assertEquals("http://localhost:8080/project.html#project?name=proj&action=roles", url);
+	}
+
+	@Test
+	void testProjectPerspectiveUrl() {
+		String url = TeamscaleUrlUtils.getProjectPerspectiveUrl(HttpUrl.get("http://localhost:8080"));
+		assertEquals("http://localhost:8080/project.html", url);
+	}
+
+}


### PR DESCRIPTION
the fragment separator "#" was encoded as "%23" in some places

also: TS now supports linking to the project permissions with aliases
(now called additional project IDs), so added a link to that in the
error messages

Addresses issue [TS-29638](https://cqse.atlassian.net/browse/TS-29638)

- [x] Changes are tested adequately - manually ran each error scenario and clicked the links
- [x] Teamscale documentation updated in case of relevant user-visible changes
- [x] CHANGELOG.md updated
- [x] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)

Please respect the vote of the [Teamscale bot](https://demo.teamscale.com) or flag irrelevant findings as tolerated or
false positives. If you feel that the Teamscale config or architecture file needs adjustment, please state so in a
comment and discuss this with your reviewer.

