### PR TITLE
TS-32867 display url instead of java object reference in error message

### DIFF
--- a/src/main/java/com/teamscale/upload/utils/LogUtils.java
+++ b/src/main/java/com/teamscale/upload/utils/LogUtils.java
@@ -21,7 +21,8 @@ public class LogUtils {
 	 * Print error message and server response, then exit program
 	 */
 	public static void fail(String message, SafeResponse response) {
-		fail("Upload to Teamscale failed:\n\n" + message + "\n\nTeamscale's response:\n" + response.toString() + "\n"
+		String url = response.unsafeResponse.request().url().toString();
+		fail("Upload to Teamscale failed:\n\n" + message + "\n\nTeamscale's response:\n" + url + "\n"
 				+ response.body);
 	}
 


### PR DESCRIPTION
Addresses issue TS-32867

- [ ] Changes are tested adequately
- [ ] Teamscale documentation updated in case of relevant user-visible changes
- [ ] CHANGELOG.md updated
- [ ] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)

Please respect the vote of the [Teamscale bot](https://cqse.teamscale.io/) or flag irrelevant findings as tolerated or
false positives. If you feel that the Teamscale config or architecture file needs adjustment, please state so in a
comment and discuss this with your reviewer.

