### PR TITLE
TS-33296 Fix Ubuntu version of Linux build

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,7 +10,8 @@ on:
 jobs:
   build-linux:
     name: Linux Build
-    runs-on: ubuntu-latest
+    # Build against a fixed version, as it determines or minimal Glibc requirements.
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up GraalVM
@@ -24,6 +25,8 @@ jobs:
           TEAMSCALE_ACCESS_KEY: ${{ secrets.TEAMSCALE_ACCESS_KEY }}
         run: mvn clean verify
       - name: Reduce Image Size
+        # As `upx` creates a statically-linked executable, the `runs-on` image
+        # above determines the minimally required version of Glibc.
         uses: crazy-max/ghaction-upx@v1
         with:
           version: latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ We use [semantic versioning](http://semver.org/):
 
 # Next Release
 
+# 2.7.1
+- [fix] restore compatibility with Ubuntu 20.04 LTS
+
 # 2.7.0
 - [fix] response message contained object identifier instead of meaningful information
 - [fix] error message on file-access problems contained stack trace


### PR DESCRIPTION
As `upx` creates statically-linked executables, the Ubuntu version implicitly determines the minimally required Glibc version, too.

Addresses issue TS-XXXXX

- [ ] Changes are tested adequately
- [ ] Teamscale documentation updated in case of relevant user-visible changes
- [x] CHANGELOG.md updated
- [ ] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)

Please respect the vote of the [Teamscale bot](https://cqse.teamscale.io/) or flag irrelevant findings as tolerated or
false positives. If you feel that the Teamscale config or architecture file needs adjustment, please state so in a
comment and discuss this with your reviewer.

