### PR TITLE
TS-38886 add jlink runtime dependency for gson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ runtime {
 			'java.logging', // For package java.util.logging (used by Google Guava)
 			'java.naming', // For package javax.naming (used by Apache HttpClient)
 			'jdk.crypto.ec', // For Elliptic Curve algorithms over TLS
+			'jdk.unsupported', // For GSON
 	]
 
 	def ADOPTIUM_BINARY_REPOSITORY = 'https://api.adoptium.net/v3/binary'


### PR DESCRIPTION
Addresses issue TS-38886

- [ ] Changes are tested adequately
  - [ ] The test still fails locally, but not with an exception. The assertion does not hold. Not sure why.
- [x] Teamscale documentation updated in case of relevant user-visible changes
- [ ] CHANGELOG.md updated
- [X] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)

Please respect the vote of the [Teamscale bot](https://cqse.teamscale.io/) or flag irrelevant findings as tolerated or
false positives. If you feel that the Teamscale config or architecture file needs adjustment, please state so in a
comment and discuss this with your reviewer.

