### PR TITLE
TS-42220 update doc of --format and --input

### DIFF
--- a/.github/workflows/build-graalvm.yml
+++ b/.github/workflows/build-graalvm.yml
@@ -16,7 +16,7 @@ jobs:
   build-linux-graalvm:
     name: Linux graalvm Build
     # Build against a fixed version, as it determines our minimal Glibc requirements.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up GraalVM

--- a/.github/workflows/build-jlink.yml
+++ b/.github/workflows/build-jlink.yml
@@ -17,7 +17,7 @@ jobs:
     # Build on a fixed version, for stability of the release artifacts.
     # In the graalvm build, this also ensures a fixed version of Glibc, but I think that is not required in the jlink
     # build (because we distribute a JVM, not build an executable).
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: 'Checkout project sources'
         uses: actions/checkout@v4

--- a/src/main/java/com/teamscale/upload/CommandLine.java
+++ b/src/main/java/com/teamscale/upload/CommandLine.java
@@ -74,6 +74,16 @@ public class CommandLine {
 	public final List<String> files;
 	/**
 	 * The input file to use or null if none is given.
+	 * <p>
+	 * The file defines a mapping from report files to report-file-format.
+	 * For example,
+	 * <pre>
+	 * [jacoco]
+	 * src\test\resources\coverage_files\test*.simple
+	 *
+	 * [simple]
+	 * src/test/resources/coverage_files/coverage.simple
+	 * </pre>
 	 */
 	public final Path inputFile;
 	/**
@@ -177,7 +187,8 @@ public class CommandLine {
 						+ " and one for JaCoCo coverage).");
 		parser.addArgument("-f", "--format").metavar("FORMAT").required(false)
 				.help("The file format of the reports which are specified as command line arguments."
-						+ "\nSee http://cqse.eu/upload-formats for a full list of supported file formats.");
+						+ "\nSee http://cqse.eu/upload-formats for a full list of supported file formats."
+						+ "\nA report format must be supplied for each report file, either via --format or via --input.");
 		parser.addArgument("-c", "--commit").metavar("REVISION").required(false)
 				.help("The version control commit for which you obtained the report files."
 						+ " E.g. if you obtained a test coverage report in your CI pipeline, then this"
@@ -203,7 +214,8 @@ public class CommandLine {
 						+ " useful meta-information about the upload and the machine performing it.");
 		parser.addArgument("-i", "--input").metavar("INPUT").required(false)
 				.help("A file which contains additional report file patterns. See INPUTFILE for a"
-						+ " detailed description of the file format.");
+						+ " detailed description of the file format."
+						+ "\nA report format must be supplied for each report file, either via --format or via --input.");
 		parser.addArgument("-k", "--insecure").action(Arguments.storeTrue()).required(false)
 				.help("Causes SSL certificates to be accepted without validation, which makes"
 						+ " using this tool with self-signed or invalid certificates easier.");


### PR DESCRIPTION
Addresses issue TS-42220

* Improved documentation of --format and --input (we need at least one of them)
* github deprecated the ubuntu 20.04 runners, so I had to update to 22.04

