### PR TITLE
TS-45539 Remove jlink mention from artifacts

### DIFF
--- a/.github/workflows/build-jlink.yml
+++ b/.github/workflows/build-jlink.yml
@@ -74,20 +74,14 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: ${{ env.DISTRIBUTIONS_DIR }}
-      - name: Rename Distributions
-        run: |
-          (cd $DISTRIBUTIONS_DIR/${ARTIFACT_NAME} && mv teamscale-upload-linux-x86_64.zip ../teamscale-upload-jlink-linux-x86_64.zip)
-          (cd $DISTRIBUTIONS_DIR/${ARTIFACT_NAME} && mv teamscale-upload-windows-x86_64.zip ../teamscale-upload-jlink-windows-x86_64.zip)
-          (cd $DISTRIBUTIONS_DIR/${ARTIFACT_NAME} && mv teamscale-upload-macos-x86_64.zip ../teamscale-upload-jlink-macos-x86_64.zip)
-          (cd $DISTRIBUTIONS_DIR/${ARTIFACT_NAME} && mv teamscale-upload-macos-aarch64.zip ../teamscale-upload-jlink-macos-aarch64.zip)
       - name: List downloaded distributions
-        run: ls -1 $DISTRIBUTIONS_DIR/*.zip
+        run: ls -1 $DISTRIBUTIONS_DIR/$ARTIFACT_NAME/*.zip
       - name: Upload Release Assets
         id: create_release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}
-          file: ${{ env.DISTRIBUTIONS_DIR }}/teamscale-upload-jlink-*.zip
+          file: ${{ env.DISTRIBUTIONS_DIR }}/${{ env.ARTIFACT_NAME }}/teamscale-upload-*.zip
           file_glob: true
           overwrite: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ We use [semantic versioning](http://semver.org/):
 
 # Next Release
 
+# 2.9.13
+- [maintenance] removed `jlink` mentions from published artifacts
+
 # 2.9.12
  - [feature] added `--max-attempts` option to retry uploads on transient errors
  - [deprecation] The graalVM distribution of teamscale-upload is discontinued. The previous release (2.9.11) is the last release with a graal-vm distribution. To migrate from the graal-vm distribution to the new gradle-based distribution, simply call `bin/teamscale-upload` instead of `teamscale-upload`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ We use [semantic versioning](http://semver.org/):
 
 # 2.9.13
 - [maintenance] removed `jlink` mentions from published artifacts
+- [maintenance] dropped level of "Request successful" logging to `debug`
 
 # 2.9.12
  - [feature] added `--max-attempts` option to retry uploads on transient errors

--- a/README.md
+++ b/README.md
@@ -15,16 +15,15 @@ If you want to use the tool as part of a GitHub build pipeline, consider using t
 
 For a local setup (on a build machine), the [Download](https://github.com/cqse/teamscale-upload/releases/latest) page offers native executables for Windows and Linux (no other tools required on the machine).
 
-Our distributions contain the `teamscale-upload` tool bundled with OS-specific java execution environment. 
+Our distributions contain the `teamscale-upload` tool bundled with OS-specific java execution environment.
 On the [Download](https://github.com/cqse/teamscale-upload/releases/latest) page, we offer a distribution based on jlink.
 
 ## Tool Usage
-### jlink Distribution for Windows
+### Distribution for Windows
 [Documentation](distribution_readme/README_WINDOWS.md)
-### jlink Distributions for Unix-based Systems
+### Distributions for Unix-based Systems
 [Documentation](distribution_readme/README_UNIX.md)
 
 ## Tool Development
 
 [Developer Documentation](README_DEV_SETUP.md)
-

--- a/src/main/java/com/teamscale/upload/client/TeamscaleClient.java
+++ b/src/main/java/com/teamscale/upload/client/TeamscaleClient.java
@@ -233,7 +233,7 @@ public class TeamscaleClient {
 		try (Response response = client.newCall(request).execute()) {
 			SafeResponse safeResponse = new SafeResponse(response);
 			handleErrors(safeResponse, commandLine);
-			LogUtils.info("Request was successful");
+			LogUtils.debug("Request successful: " + request.method() + " " + url + " (HTTP " + safeResponse.unsafeResponse.code() + ")");
 			return safeResponse.body;
 		} catch (UnknownHostException e) {
 			LogUtils.failWithoutStackTrace(

--- a/src/main/java/com/teamscale/upload/client/TeamscaleClient.java
+++ b/src/main/java/com/teamscale/upload/client/TeamscaleClient.java
@@ -233,7 +233,7 @@ public class TeamscaleClient {
 		try (Response response = client.newCall(request).execute()) {
 			SafeResponse safeResponse = new SafeResponse(response);
 			handleErrors(safeResponse, commandLine);
-			LogUtils.debug("Request successful: " + request.method() + " " + url + " (HTTP " + safeResponse.unsafeResponse.code() + ")");
+			LogUtils.debug("Request successful: %s %s (HTTP %d)", request.method(), url, safeResponse.unsafeResponse.code());
 			return safeResponse.body;
 		} catch (UnknownHostException e) {
 			LogUtils.failWithoutStackTrace(

--- a/src/main/java/com/teamscale/upload/utils/LogUtils.java
+++ b/src/main/java/com/teamscale/upload/utils/LogUtils.java
@@ -108,6 +108,13 @@ public class LogUtils {
 		}
 	}
 
+	/** See {@link #debug(String)}. Formats the message lazily via {@link String#format}. */
+	public static void debug(String template, Object... args) {
+		if (debugLogEnabled) {
+			System.out.println("DEBUG: " + String.format(template, args));
+		}
+	}
+
 	/**
 	 * Print a debug message to stdout and log the given throwable.
 	 * <p>


### PR DESCRIPTION
Addresses issue TS-46027 (via TS-45539)

- [X] Changes are tested adequately
- [X] Teamscale documentation updated in case of relevant user-visible changes
- [X] CHANGELOG.md updated
- [X] Present new features in [N&N](https://wiki.cqse.eu/pages/viewpage.action?pageId=689566)

Please respect the vote of the [Teamscale bot](https://cqse.teamscale.io/) or flag irrelevant findings as tolerated or
false positives. If you feel that the Teamscale config or architecture file needs adjustment, please state so in a
comment and discuss this with your reviewer.

---

This PR removes the `jlink` tag from the published artifacts as there is no longer an alternative version.
