### PR TITLE
TS-47611 Install git in the Docker image and add a /workspace working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ gradle-app.setting
 # Avoid ignoring Gradle wrappper properties
 !/gradle/wrapper/gradle-wrapper.properties
 
+docker-context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ We use [semantic versioning](http://semver.org/):
 - PATCH version when you make backwards compatible bug fixes.
 
 # Next Release
+- [fix] the Docker image now contains a `git` binary, so revision auto-detection works for a mounted repository
+- [feature] the Docker image now uses `/workspace` as its working directory, so a repository can be mounted with `-v "$PWD:/workspace:ro"` without passing `-w`
 
 # 2.10.1
 - [feature] publish a Docker image `cqse/teamscale-upload` to Docker Hub on each release, tagged with the release version and `latest`. `teamscale-upload` is on the `PATH` inside the image, so it can also be called by name if you override the entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,19 @@ FROM ubuntu:26.04@sha256:3131b4cc82a783df6c9df078f86e01819a13594b865c2cad47bd1bc
 RUN groupadd --system teamscale \
  && useradd --system --gid teamscale --create-home teamscale
 
+# teamscale-upload auto-detects the uploaded revision by running `git rev-parse` in the working
+# directory, so the image needs a git binary. --no-install-recommends keeps out git-man and friends.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git \
+ && rm -rf /var/lib/apt/lists/*
+
+# A repository bind-mounted from the host belongs to the host user's UID, not to the `teamscale`
+# user this image runs as. git would refuse such a repository as "dubious ownership" and
+# auto-detection would fail with a misleading "not within a Git repository" message. We accept the
+# weakened ownership check: the container has a single purpose and the user mounts their own
+# repository on purpose.
+RUN git config --system --add safe.directory '*'
+
 # Self-contained jlink distribution: launcher + bundled (glibc) JVM + all jars.
 # Extracted from teamscale-upload-linux-x86_64.zip (./gradlew customRuntimeZip-linux-x86_64) into
 # the build context. Not the `distZip` output (teamscale-upload-<version>.zip): that one ships no
@@ -18,6 +31,11 @@ COPY teamscale-upload/ /opt/teamscale-upload/
 # would shadow a real JDK installed in a derived image with our stripped 4-module runtime, which
 # then fails in confusing ways for anything but teamscale-upload itself.
 RUN ln -s /opt/teamscale-upload/bin/teamscale-upload /usr/local/bin/teamscale-upload
+
+# Default mount point for report files with plain `docker run -v "$PWD:/workspace:ro"`.
+# CI systems (GitLab, Jenkins, Azure DevOps) override this with their own workspace path.
+RUN install -d -o teamscale -g teamscale /workspace
+WORKDIR /workspace
 
 USER teamscale
 ENTRYPOINT ["teamscale-upload"]


### PR DESCRIPTION
## TS-47611

`teamscale-upload` auto-detects the uploaded revision by running `git rev-parse` in the working directory, but the Docker image shipped no `git` binary, so auto-detection could never succeed inside the container.

### Changes

- Install `git` in the Docker image.
- Set `safe.directory '*'` for the `teamscale` user. A repository bind-mounted from the host belongs to the host user's UID, not to the `teamscale` user the image runs as, and git would otherwise reject it as "dubious ownership". The weakened ownership check is acceptable because the container has a single purpose and the user mounts their own repository on purpose. The alternative — documenting `docker run --user $(id -u):$(id -g)` — keeps git's protection but makes auto-detection fail silently for everyone who does not read the documentation.
- Add a `/workspace` working directory so that both report paths and revision detection have a default mount point and a plain `-v "$PWD:/workspace:ro"` suffices.
- Ignore the `docker-context` file created during the build.

### Testing

Build the image and run it against a bind-mounted repository without passing `--commit`/`--branch`; the revision should be detected automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
